### PR TITLE
Increase total memory rows to 11

### DIFF
--- a/src/game_objects/custom_settings_dialog.py
+++ b/src/game_objects/custom_settings_dialog.py
@@ -20,7 +20,7 @@ class CustomSettingsDialog(GameObject):
         self._num_processes_selector = OptionSelector([str(i) for i in range(1, 43)], self._config['num_processes_at_startup'] - 1)
         self.children.append(self._num_processes_selector)
         
-        self._num_ram_rows_selector = OptionSelector([str(i) for i in range(1, 11)], self._config['num_ram_rows'] - 1)
+        self._num_ram_rows_selector = OptionSelector([str(i) for i in range(1, 12)], self._config['num_ram_rows'] - 1)
         self.children.append(self._num_ram_rows_selector)
         
         self._new_process_probability_selector = OptionSelector([str(i) + ' %' for i in range(0, 105, 5)])

--- a/src/game_objects/page_manager.py
+++ b/src/game_objects/page_manager.py
@@ -4,7 +4,7 @@ from game_objects.page import Page
 from game_objects.page_slot import PageSlot
 
 class PageManager(GameObject):
-    _TOTAL_ROWS = 10
+    _TOTAL_ROWS = 11
     
     def __init__(self, game):
         self._game = game


### PR DESCRIPTION
Since version 1.1.0, the game allowed the mathematical possibility of running out of page slots (RAM + disk). This was unintended and is fixed by adding an extra row of page slots.