### PR TITLE
Make MOUSE_LEFT_DRAG also move processes

### DIFF
--- a/src/game_objects/process.py
+++ b/src/game_objects/process.py
@@ -150,7 +150,7 @@ class Process(GameObject):
                 self._page_manager.delete_page(page)
 
     def _check_if_clicked_on(self, event):
-        if event.type == GameEventType.MOUSE_LEFT_CLICK or event.type == GameEventType.MOUSE_LEFT_DRAG:
+        if event.type in set(GameEventType.MOUSE_LEFT_CLICK, GameEventType.MOUSE_LEFT_DRAG):
             return self.starvation_level < 6 and self._view.collides(
                 *event.get_property('position'))
         return False
@@ -167,8 +167,8 @@ class Process(GameObject):
         if not self._check_if_in_motion():
             for event in events:
                 if self._check_if_clicked_on(event):
-                        self._on_click()
-                        break
+                    self._on_click()
+                    break
 
         if not self.has_ended:
             pages_in_swap = 0

--- a/src/game_objects/process.py
+++ b/src/game_objects/process.py
@@ -156,10 +156,7 @@ class Process(GameObject):
         return False
 
     def _check_if_in_motion(self):
-        if self._view.target_x is not None or self._view.target_y is not None:
-            return True
-        return False
-
+        return self._view.target_x is not None or self._view.target_y is not None
     def _on_click(self):
         if self.has_cpu:
             self.yield_cpu()

--- a/src/game_objects/process.py
+++ b/src/game_objects/process.py
@@ -150,7 +150,7 @@ class Process(GameObject):
                 self._page_manager.delete_page(page)
 
     def _check_if_clicked_on(self, event):
-        if event.type == GameEventType.MOUSE_LEFT_CLICK:
+        if event.type == GameEventType.MOUSE_LEFT_CLICK or event.type == GameEventType.MOUSE_LEFT_DRAG:
             return self.starvation_level < 6 and self._view.collides(
                 *event.get_property('position'))
         return False

--- a/src/game_objects/process.py
+++ b/src/game_objects/process.py
@@ -150,7 +150,7 @@ class Process(GameObject):
                 self._page_manager.delete_page(page)
 
     def _check_if_clicked_on(self, event):
-        if event.type in set(GameEventType.MOUSE_LEFT_CLICK, GameEventType.MOUSE_LEFT_DRAG):
+        if event.type in set([GameEventType.MOUSE_LEFT_CLICK, GameEventType.MOUSE_LEFT_DRAG]):
             return self.starvation_level < 6 and self._view.collides(
                 *event.get_property('position'))
         return False

--- a/src/game_objects/process.py
+++ b/src/game_objects/process.py
@@ -157,6 +157,7 @@ class Process(GameObject):
 
     def _check_if_in_motion(self):
         return self._view.target_x is not None or self._view.target_y is not None
+
     def _on_click(self):
         if self.has_cpu:
             self.yield_cpu()

--- a/src/game_objects/process.py
+++ b/src/game_objects/process.py
@@ -155,6 +155,11 @@ class Process(GameObject):
                 *event.get_property('position'))
         return False
 
+    def _check_if_in_motion(self):
+        if self._view.target_x is not None or self._view.target_y is not None:
+            return True
+        return False
+
     def _on_click(self):
         if self.has_cpu:
             self.yield_cpu()
@@ -162,9 +167,11 @@ class Process(GameObject):
             self.use_cpu()
 
     def update(self, current_time, events):
-        for event in events:
-            if self._check_if_clicked_on(event):
-                self._on_click()
+        if not self._check_if_in_motion():
+            for event in events:
+                if self._check_if_clicked_on(event):
+                        self._on_click()
+                        break
 
         if not self.has_ended:
             pages_in_swap = 0


### PR DESCRIPTION
After playing for a bit, I desired to be able to move processes more quickly onto the CPU in the same manner as moving pages of memory by dragging over them.

I think this addition raises the skill ceiling a bit higher without impacting lower level play.

On the other hand, I'm not offended if you prefer the current system, which trains fast precision clicking skills for moving many processes at once.