### PR TITLE
Fix ghost RAM slot when deleting a page with a pending swap

### DIFF
--- a/src/scene_objects/page_manager.py
+++ b/src/scene_objects/page_manager.py
@@ -154,6 +154,7 @@ class PageManager(SceneObject):
             page.cancel_swap()
 
     def delete_page(self, page):
+        page.cancel_swap()
         for ram_slot in self._ram_slots:
             if ram_slot.page == page:
                 ram_slot.page = None

--- a/src/tests/scene_objects/test_page_manager.py
+++ b/src/tests/scene_objects/test_page_manager.py
@@ -392,4 +392,63 @@ class TestPageManager:
             child for child in page_manager.children if isinstance(child, PageSlot) and child.page == page_to_delete
         ), None)
         assert containing_slot is None
+
+    def test_delete_page_does_not_ghost_ram_slot_from_pending_swap_in(self, page_manager):
+        # A page queued for swap-in (waiting, not yet started) is deleted while
+        # its process is terminated. The pending swap must not later reserve a
+        # RAM slot for a page that no longer exists (a ghost slot that never
+        # completes and visually appears free).
+        ram_pages = []
+        for i in range(PageManager.get_num_cols()):
+            ram_pages.append(page_manager.create_page(1, i))
+
+        disk_page = page_manager.create_page(2, 0)
+        assert disk_page.on_disk
+
+        page_manager.swap_page(disk_page)
+        assert disk_page.swap_requested
+        assert not disk_page.swap_in_progress
+
+        page_manager.delete_page(disk_page)
+        page_manager.delete_page(ram_pages[0])
+
+        page_manager.update(2000, [])
+
+        ghost_slot = next((
+            child for child in page_manager.children
+            if isinstance(child, PageSlot) and child.page is disk_page
+        ), None)
+        assert ghost_slot is None
+
+    def test_pending_swap_in_does_not_block_new_swap_after_page_deletion(self, page_manager):
+        # Regression for the reported bug: after a process holding a queued
+        # swap-in page is terminated (freeing a RAM slot but orphaning the queued
+        # entry), clicking another disk page must still swap it into RAM instead
+        # of turning TEAL forever ("nothing happens").
+        ram_pages = []
+        for i in range(PageManager.get_num_cols()):
+            ram_pages.append(page_manager.create_page(1, i))
+
+        queued_disk_page = page_manager.create_page(1, PageManager.get_num_cols())
+        assert queued_disk_page.on_disk
+        other_disk_page = page_manager.create_page(1, PageManager.get_num_cols() + 1)
+        assert other_disk_page.on_disk
+
+        page_manager.swap_page(queued_disk_page)
+        page_manager.delete_page(queued_disk_page)
+        page_manager.delete_page(ram_pages[0])
+
+        page_manager.update(2000, [])
+
+        page_manager.swap_page(other_disk_page)
+        assert other_disk_page.swap_requested
+        assert not other_disk_page.swap_in_progress
+
+        page_manager.update(2001, [])
+        assert other_disk_page.swap_in_progress
+
+        page_manager.update(3000, [])
+        assert not other_disk_page.on_disk
+        assert not other_disk_page.swap_requested
+        assert not other_disk_page.swap_in_progress
          


### PR DESCRIPTION
## Problem
When a process is terminated while one of its pages is waiting in the swap queue (e.g. the player clicked a disk page to swap it into RAM, but the swap had not started yet because `parallel_swaps` was saturated or RAM was full), `PageManager.delete_page` removed the page from its source slot, children, and `_pages`, but **did not cancel the pending swap**. The page stayed in `_swap_in_queue` with `_waiting_to_swap = True`.

On a subsequent frame, `_handle_swap_queues` dequeued the orphaned page. Since `swap_requested` was still `True`, it passed the cancellation guard and `start_swap` reserved a destination RAM slot for a page that no longer exists. Because the deleted page is no longer in `children`, its `_update_swap` never runs, so the swap never completes: the RAM slot is **permanently ghost-occupied** while visually appearing free (no page drawn, no progress bar).

Once only one visually-free RAM slot remains and it is such a ghost, every subsequent disk→RAM click enqueues a page that can never start — it turns TEAL and "nothing happens", matching the reported bug.

## Root cause in one line
`page_manager.py:157` (`delete_page`) did not call `page.cancel_swap()`, leaving a stale entry in `_swap_in_queue`/`_swap_out_queue` that later reserves a slot for a deleted page.

## Fix
Call `page.cancel_swap()` at the top of `delete_page`. For a waiting swap this clears `_waiting_to_swap`, so the dequeue guard `if not page.swap_requested: continue` silently drops the stale entry. For an in-progress swap it also frees the already-reserved destination slot (`_swapping_to.page = None`), preventing the symmetric ghost on the swap-out / disk side.

This restores the existing slot in `delete_page`'s loops to clean up source slots, and reuses the existing `cancel_swap` state machine rather than introducing new logic (open-closed friendly).

## Scope
The entire swap state machine (`init_swap`, `start_swap`, `cancel_swap`, `_update_swap`, `_handle_swap_queues`, `swap_page`, `cancel_page_swap`) is byte-for-byte identical on `main`, so this bug exists on `main` too — this is not a regression of any feature branch.

## Tests
Two regression tests in `test_page_manager.py` (TDD: both fail on `main`, pass with this fix):
- `test_delete_page_does_not_ghost_ram_slot_from_pending_swap_in` — asserts no RAM slot ends up reserved by a deleted page after the queue drains.
- `test_pending_swap_in_does_not_block_new_swap_after_page_deletion` — reproduces the user-facing symptom: after a queued swap-in page is deleted, clicking another disk page actually starts and completes its swap into RAM instead of staying TEAL forever.

## Verification
- `pipenv run pylint src/scene_objects/page_manager.py` — clean (the 9.97/10 deduction is a pre-existing `E0611` in `sandbox/story_stage.py`, unrelated).
- `pipenv run pytest` — 430 passed.